### PR TITLE
update markdown-toc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "markdown-toc": "^0.12.5"
+    "markdown-toc": "^0.12.6"
   }
 }


### PR DESCRIPTION
with 0.12.6, the problem with having colons in headlines should be fixed. Closes #1
