### PR TITLE
update markdown-toc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "markdown-toc": "^0.12.6"
+    "markdown-toc": "^0.12.9"
   }
 }


### PR DESCRIPTION
Because of these changes:
- https://github.com/jonschlinkert/markdown-toc/pull/52
- https://github.com/jonschlinkert/markdown-toc/issues/51
- https://github.com/jonschlinkert/markdown-toc/issues/53
